### PR TITLE
Fix duplicate enabler creation and centralize version management

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,12 @@ The system includes automated state management:
 
 ## Version History
 
+### v1.0.2 - Defect Fixes and Version Management ✅
+- **DUPLICATE ENABLER FIX**: Fixed duplicate enabler file creation issue where inconsistent filename generation between frontend and backend created files with and without `-enabler` suffix
+- **CENTRALIZED VERSION MANAGEMENT**: Updated all code to use package.json as single source of truth for version information
+- **FILENAME CONSISTENCY**: Standardized enabler file naming to use `-enabler.md` suffix consistently across the application
+- **VERSION SYNC SCRIPT**: Added `npm run version:sync` command to synchronize versions between root and client package.json files
+
 ### v1.0.0 - Initial Open Source Release ✅
 - **APACHE 2.0 LICENSE**: Released under Apache 2.0 license with full open source compliance
 - **COMPREHENSIVE FEATURE SET**: Complete PRD management system with capabilities, enablers, and requirements tracking

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anvil-client",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "type": "module",
   "author": "Darcy Davidson",

--- a/client/src/components/DocumentEditor.jsx
+++ b/client/src/components/DocumentEditor.jsx
@@ -279,9 +279,9 @@ export default function DocumentEditor() {
             for (const enabler of formData.enablers) {
               if (enabler.id) {
                 try {
-                  // Find enabler filename - try different naming conventions
-                  const enablerFilename = `${enabler.id.toLowerCase()}-enabler.md`
-                  const enablerPath = `${enabler.id.toLowerCase()}-enabler.md`
+                  // Use consistent filename generation
+                  const enablerFilename = idToFilename(enabler.id, 'enabler')
+                  const enablerPath = idToFilename(enabler.id, 'enabler')
                   const newEnablerPath = `${formData.selectedPath}/${enablerFilename}`
 
                   console.log(`[ENABLER-MOVE] Moving enabler ${enabler.id} to ${newEnablerPath}`)

--- a/client/src/utils/fileUtils.js
+++ b/client/src/utils/fileUtils.js
@@ -19,12 +19,23 @@
 /**
  * Converts a document ID to a filename (preferred method for uniqueness)
  * @param {string} id - The document ID (e.g., CAP-001, ENB-001)
- * @param {string} type - The document type (not used, kept for compatibility)
- * @returns {string} - The filename based on ID only (e.g., CAP-001.md)
+ * @param {string} type - The document type (capability, enabler)
+ * @returns {string} - The filename with appropriate suffix (e.g., cap-001-capability.md, enb-001-enabler.md)
  */
 export function idToFilename(id, type) {
   if (!id) return '';
-  return `${id.toLowerCase()}.md`;
+
+  const lowerId = id.toLowerCase();
+
+  // Add type suffix for consistency with backend naming
+  if (type === 'capability') {
+    return `${lowerId}-capability.md`;
+  } else if (type === 'enabler') {
+    return `${lowerId}-enabler.md`;
+  }
+
+  // Fallback for unknown types
+  return `${lowerId}.md`;
 }
 
 /**
@@ -60,8 +71,9 @@ export function filenameToName(filename) {
 
   // Check if it's an ID-based filename (starts with CAP- or ENB-)
   if (nameWithoutExtension.match(/^(CAP|ENB)-/i)) {
-    // For ID-based filenames, return the ID as-is (uppercase)
-    return nameWithoutExtension.toUpperCase();
+    // For ID-based filenames, remove type suffix if present and return the ID as-is (uppercase)
+    const idWithoutSuffix = nameWithoutExtension.replace(/-capability$|-enabler$/, '');
+    return idWithoutSuffix.toUpperCase();
   }
 
   // For legacy name-based filenames, remove type suffix and format

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anvil",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Product Requirements Document management application for Capabilities and Enablers",
   "main": "server.js",
   "author": "Darcy Davidson",
@@ -31,7 +31,8 @@
     "build": "cd client && npm run build",
     "build:start": "npm run build && npm start",
     "install:all": "npm install && cd client && npm install",
-    "dev:full": "concurrently \"npm run dev\" \"npm run client\""
+    "dev:full": "concurrently \"npm run dev\" \"npm run client\"",
+    "version:sync": "node -e \"const pkg=require('./package.json'); const clientPkg=require('./client/package.json'); clientPkg.version=pkg.version; require('fs').writeFileSync('./client/package.json', JSON.stringify(clientPkg, null, 2));\""
   },
   "dependencies": {
     "express": "^4.18.2",

--- a/server.js
+++ b/server.js
@@ -25,7 +25,7 @@ try {
   version = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
 } catch (error) {
   console.error('Error loading package.json, using default:', error.message);
-  version = { version: '5.7.1' };
+  version = { version: 'unknown' };
 }
 
 // Security utility for path validation
@@ -1760,7 +1760,7 @@ async function generateEnablerContentFromTemplate(enabler, capabilityId) {
       '- \\*\\*Code Review\\*\\*: Not Required': `- **Code Review**: ${config.defaults?.codeReview || 'Not Required'}`,
       '- \\*\\*Created Date\\*\\*: YYYY-MM-DD': `- **Created Date**: ${currentDate}`,
       '- \\*\\*Last Updated\\*\\*: YYYY-MM-DD': `- **Last Updated**: ${currentDate}`,
-      '- \\*\\*Version\\*\\*: X\\.Y': `- **Version**: 1.0`
+      '- \\*\\*Version\\*\\*: X\\.Y': `- **Version**: ${version.version}`
     }
     
     // Apply replacements with validation
@@ -1809,7 +1809,7 @@ function generateEnablerContentFallback(enabler, capabilityId) {
 - **Developer**: [Development Team/Lead]
 - **Created Date**: ${currentDate}
 - **Last Updated**: ${currentDate}
-- **Version**: 1.0
+- **Version**: ${version.version}
 
 ## Technical Overview
 ### Purpose

--- a/start-anvil.bat
+++ b/start-anvil.bat
@@ -1,7 +1,7 @@
 @echo off
 
-REM Read version from version.json
-for /f "tokens=*" %%i in ('powershell -Command "(Get-Content version.json | ConvertFrom-Json).version"') do set VERSION=%%i
+REM Read version from package.json
+for /f "tokens=*" %%i in ('powershell -Command "(Get-Content package.json | ConvertFrom-Json).version"') do set VERSION=%%i
 
 echo ============================================
 echo        Starting Anvil v%VERSION% - Level 1!

--- a/start-anvil.sh
+++ b/start-anvil.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Read version from version.json
-VERSION=$(cat version.json | grep -Po '"version":\s*"\K[^"]*')
+# Read version from package.json
+VERSION=$(cat package.json | grep -Po '"version":\s*"\K[^"]*')
 
 echo "============================================"
 echo "       Starting Anvil v$VERSION - Level 1!"


### PR DESCRIPTION
- Fix duplicate enabler file creation issue where inconsistent filename generation between frontend and backend created both `enb-123-enabler.md` and `enb-123.md` files for the same enabler
- Update idToFilename() utility to include type suffixes consistently
- Update DocumentEditor to use utility function instead of hardcoded naming
- Centralize version management to use package.json as single source of truth
- Remove hardcoded version references from server.js templates
- Fix startup scripts to read from package.json instead of missing version.json
- Add version:sync npm script to synchronize client package.json with root
- Update README with v1.0.2 release notes